### PR TITLE
Don't duplicate conda channels

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -29,7 +29,6 @@ jobs:
           python-version: 3.7
           activate-environment: hyp3-insar-gamma
           environment-file: conda-env.yml
-          channels: conda-forge, nodefaults
 
       - name: Pytest in conda environment
         shell: bash -l {0}


### PR DESCRIPTION
Eliminates warning in Github Actions workflow