### PR TITLE
Drop opressive language

### DIFF
--- a/hyp3_insar_gamma/etc/README_InSAR_GAMMA.txt
+++ b/hyp3_insar_gamma/etc/README_InSAR_GAMMA.txt
@@ -11,8 +11,8 @@ Processing Date/Time: [DATE] [TIME] UTC
 
 The product folder is named using the following convention:
 S1xy-aaaaaaaaTbbbbbb_ggggggggThhhhhh-pp-qqqqqq-rrd-ssxs-int-ccccc  
-x:      	Sentinel-1 Mission (A or B) of reference (master) granule  
-y:      	Sentinel-1 Mission (A or B) of secondary (slave) granule  
+x:      	Sentinel-1 Mission (A or B) of reference granule  
+y:      	Sentinel-1 Mission (A or B) of secondary granule  
 aaaaaaaa: 	Start Date of Acquisition (YYYYMMDD) of reference granule  
 bbbbbb:   	Start Time of Acquisition (HHMMSS) of reference granule  
 gggggggg: 	Start Date of Acquisition (YYYYMMDD) of secondary granule  
@@ -106,7 +106,7 @@ The coherence map is tagged with _corr.tif
 ----------------
 ## 6. Amplitude Image
 
-The amplitude GeoTIFF indicates the calibrated radiometric backscatter from the reference (master) granule in sigma-nought power. The image is terrain corrected using a geometric correction, but not radiometrically corrected. For more informative amplitude data, order Radiometric Terrain Corrected (RTC) products for your area of interest.
+The amplitude GeoTIFF indicates the calibrated radiometric backscatter from the reference granule in sigma-nought power. The image is terrain corrected using a geometric correction, but not radiometrically corrected. For more informative amplitude data, order Radiometric Terrain Corrected (RTC) products for your area of interest.
 
 The amplitude image is tagged with _amp.tif
 

--- a/hyp3_insar_gamma/interf_pwr_s1_lt_tops_proc.py
+++ b/hyp3_insar_gamma/interf_pwr_s1_lt_tops_proc.py
@@ -114,7 +114,8 @@ def interf_pwr_s1_lt_tops_proc(reference, secondary, dem, rlooks=10, alooks=2, i
         logging.info("Starting iterative coregistration with look up table")
         for n in range(1, iterations + 1):
             coregister_data(
-                n, SLC2tab, SLC2Rtab, spar, mpar, mmli, smli, ifgname, reference, secondary, lt, rlooks, alooks, iterations
+                n, SLC2tab, SLC2Rtab, spar, mpar, mmli, smli, ifgname,
+                reference, secondary, lt, rlooks, alooks, iterations
             )
     elif step == 3:
         logging.info("Starting single interation coregistration with look up table")

--- a/hyp3_insar_gamma/interf_pwr_s1_lt_tops_proc.py
+++ b/hyp3_insar_gamma/interf_pwr_s1_lt_tops_proc.py
@@ -25,7 +25,7 @@ def create_slc2r_tab(SLC2tab, SLC2Rtab):
 
 
 def coregister_data(cnt, SLC2tab, SLC2Rtab, spar, mpar, mmli, smli, ifgname,
-                    master, slave, lt, rlooks, alooks, iterations):
+                    reference, secondary, lt, rlooks, alooks, iterations):
     if cnt < iterations + 1:
         offi = ifgname + ".off_{}".format(cnt)
     else:
@@ -39,8 +39,8 @@ def coregister_data(cnt, SLC2tab, SLC2Rtab, spar, mpar, mmli, smli, ifgname,
         offit = ifgname + ".off.it.corrected"
 
     SLC1tab = "SLC1_tab"
-    srslc = slave + ".rslc"
-    srpar = slave + ".rslc.par"
+    srslc = secondary + ".rslc"
+    srpar = secondary + ".rslc.par"
 
     execute(f"SLC_interp_lt_S1_TOPS {SLC2tab} {spar} {SLC1tab} {mpar} {lt}"
             f" {mmli} {smli} {offit} {SLC2Rtab} {srslc} {srpar}", uselogging=True)
@@ -51,7 +51,7 @@ def coregister_data(cnt, SLC2tab, SLC2Rtab, spar, mpar, mmli, smli, ifgname,
         cmd_sfx = "256 64 offsets 1 64 256 0.2"
     else:
         cmd_sfx = "512 256 - 1 16 64 0.2"
-    execute(f"offset_pwr {master}.slc {slave}.rslc {mpar} {srpar} {offi} offs snr {cmd_sfx}", uselogging=True)
+    execute(f"offset_pwr {reference}.slc {secondary}.rslc {mpar} {srpar} {offi} offs snr {cmd_sfx}", uselogging=True)
 
     with open("offsetfit{}.log".format(cnt), "w") as log:
         execute(f"offset_fit offs snr {offi} - - 0.2 1", uselogging=True, logfile=log)
@@ -60,12 +60,12 @@ def coregister_data(cnt, SLC2tab, SLC2Rtab, spar, mpar, mmli, smli, ifgname,
         ifg_diff_sfx = f'it{cnt}'
     else:
         ifg_diff_sfx = 'man'
-    execute(f"SLC_diff_intf {master}.slc {slave}.rslc {mpar} {srpar} {offi}"
+    execute(f"SLC_diff_intf {reference}.slc {secondary}.rslc {mpar} {srpar} {offi}"
             f" {ifgname}.sim_unw {ifgname}.diff0.{ifg_diff_sfx} {rlooks} {alooks} 0 0", uselogging=True)
 
     width = getParameter(offi, "interferogram_width")
     f"offset_add {offit} {offi} {offi}.temp"
-    execute(f"rasmph_pwr {ifgname}.diff0.{ifg_diff_sfx} {master}.mli {width} 1 1 0 3 3", uselogging=True)
+    execute(f"rasmph_pwr {ifgname}.diff0.{ifg_diff_sfx} {reference}.mli {width} 1 1 0 3 3", uselogging=True)
 
     if cnt == 0:
         offit = ifgname + ".off.it"
@@ -77,16 +77,16 @@ def coregister_data(cnt, SLC2tab, SLC2Rtab, spar, mpar, mmli, smli, ifgname,
         execute(f"offset_add {offit} {offi} {offi}.out", uselogging=True)
 
 
-def interf_pwr_s1_lt_tops_proc(master, slave, dem, rlooks=10, alooks=2, iterations=5, step=0):
+def interf_pwr_s1_lt_tops_proc(reference, secondary, dem, rlooks=10, alooks=2, iterations=5, step=0):
     # Setup various file names that we'll need
-    ifgname = "{}_{}".format(master, slave)
+    ifgname = "{}_{}".format(reference, secondary)
     SLC2tab = "SLC2_tab"
     SLC2Rtab = "SLC2R_tab"
-    lt = "{}.lt".format(master)
-    mpar = master + ".slc.par"
-    spar = slave + ".slc.par"
-    mmli = master + ".mli.par"
-    smli = slave + ".mli.par"
+    lt = "{}.lt".format(reference)
+    mpar = reference + ".slc.par"
+    spar = secondary + ".slc.par"
+    mmli = reference + ".mli.par"
+    smli = secondary + ".mli.par"
     off = ifgname + ".off_temp"
 
     # Make a fresh slc2r tab
@@ -108,19 +108,19 @@ def interf_pwr_s1_lt_tops_proc(master, slave, dem, rlooks=10, alooks=2, iteratio
     elif step == 1:
         logging.info("Starting initial coregistration with look up table")
         coregister_data(
-            0, SLC2tab, SLC2Rtab, spar, mpar, mmli, smli, ifgname, master, slave, lt, rlooks, alooks, iterations
+            0, SLC2tab, SLC2Rtab, spar, mpar, mmli, smli, ifgname, reference, secondary, lt, rlooks, alooks, iterations
         )
     elif step == 2:
         logging.info("Starting iterative coregistration with look up table")
         for n in range(1, iterations + 1):
             coregister_data(
-                n, SLC2tab, SLC2Rtab, spar, mpar, mmli, smli, ifgname, master, slave, lt, rlooks, alooks, iterations
+                n, SLC2tab, SLC2Rtab, spar, mpar, mmli, smli, ifgname, reference, secondary, lt, rlooks, alooks, iterations
             )
     elif step == 3:
         logging.info("Starting single interation coregistration with look up table")
         coregister_data(
             iterations + 1, SLC2tab, SLC2Rtab, spar, mpar, mmli, smli, ifgname,
-            master, slave, lt, rlooks, alooks, iterations
+            reference, secondary, lt, rlooks, alooks, iterations
         )
     else:
         logging.error("ERROR: Unrecognized step {}; must be from 0 - 2".format(step))
@@ -134,8 +134,8 @@ def main():
         description=__doc__,
     )
 
-    parser.add_argument("master", help='Master scene identifier')
-    parser.add_argument("slave", help='Slave scene identifier')
+    parser.add_argument("reference", help='Reference scene identifier')
+    parser.add_argument("secondary", help='Secondary scene identifier')
     parser.add_argument("dem", help='Dem file in SAR coordinates (e.g. ./DEM/HGT_SAR_10_2)')
     parser.add_argument("-r", "--rlooks", type=int, default=10, help="Number of range looks (def=10)")
     parser.add_argument("-a", "--alooks", type=int, default=2, help="Number of azimuth looks (def=2)")
@@ -151,7 +151,7 @@ def main():
     logging.getLogger().addHandler(logging.StreamHandler())
     logging.info("Starting run")
 
-    interf_pwr_s1_lt_tops_proc(args.master, args.slave, args.dem, rlooks=args.rlooks, alooks=args.alooks,
+    interf_pwr_s1_lt_tops_proc(args.reference, args.secondary, args.dem, rlooks=args.rlooks, alooks=args.alooks,
                                iterations=args.iter, step=args.step)
 
 

--- a/hyp3_insar_gamma/stack_sentinel.py
+++ b/hyp3_insar_gamma/stack_sentinel.py
@@ -33,12 +33,12 @@ def makeDirAndLinks(name1, name2, file1, file2, dem):
 def makeParameterFile(mydir, alooks, rlooks, dem_source):
     res = 20 * int(alooks)
 
-    master_date = mydir[:15]
-    slave_date = mydir[17:]
+    reference_date = mydir[:15]
+    secondary_date = mydir[17:]
 
-    logging.info("In directory {} looking for file with date {}".format(os.getcwd(), master_date))
-    master_file = glob.glob("*%s*.SAFE" % master_date)[0]
-    slave_file = glob.glob("*%s*.SAFE" % slave_date)[0]
+    logging.info("In directory {} looking for file with date {}".format(os.getcwd(), reference_date))
+    reference_file = glob.glob("*%s*.SAFE" % reference_date)[0]
+    secondary_file = glob.glob("*%s*.SAFE" % secondary_date)[0]
 
     with open("IFM/baseline.log", "r") as f:
         for line in f:
@@ -49,7 +49,7 @@ def makeParameterFile(mydir, alooks, rlooks, dem_source):
                 baseline = float(s[1])
 
     back = os.getcwd()
-    os.chdir(os.path.join(master_file, "annotation"))
+    os.chdir(os.path.join(reference_file, "annotation"))
 
     utctime = None
     for myfile in os.listdir("."):
@@ -66,7 +66,7 @@ def makeParameterFile(mydir, alooks, rlooks, dem_source):
     os.chdir(back)
 
     heading = None
-    name = "IFM/" + master_date[:8] + ".mli.par"
+    name = "IFM/" + reference_date[:8] + ".mli.par"
     with open(name, "r") as f:
         for line in f:
             if "heading" in line:
@@ -75,14 +75,14 @@ def makeParameterFile(mydir, alooks, rlooks, dem_source):
                 s = re.split(r'\s+', t[1])
                 heading = float(s[1])
 
-    master_file = master_file.replace(".SAFE", "")
-    slave_file = slave_file.replace(".SAFE", "")
+    reference_file = reference_file.replace(".SAFE", "")
+    secondary_file = secondary_file.replace(".SAFE", "")
 
     os.chdir("PRODUCT")
     name = "%s.txt" % mydir
     with open(name, 'w') as f:
-        f.write('Master Granule: %s\n' % master_file)
-        f.write('Slave Granule: %s\n' % slave_file)
+        f.write('Reference Granule: %s\n' % reference_file)
+        f.write('Secondary Granule: %s\n' % secondary_file)
         f.write('Baseline: %s\n' % baseline)
         f.write('UTCtime: %s\n' % utctime)
         f.write('Heading: %s\n' % heading)
@@ -164,18 +164,18 @@ def procS1StackGAMMA(alooks=4, rlooks=20, csvFile=None, dem=None, use_opentopo=N
                 logging.info("Processing directory %s" % mydir)
                 os.chdir(mydir)
 
-                master = mydir.split("_")[0]
-                slave = mydir.split("_")[1]
+                reference = mydir.split("_")[0]
+                secondary = mydir.split("_")[1]
 
-                masterFile = None
-                slaveFile = None
+                reference_file = None
+                secondary_file = None
                 for myfile in glob.glob("*.SAFE"):
-                    if master in myfile:
-                        masterFile = myfile
-                    if slave in myfile:
-                        slaveFile = myfile
+                    if reference in myfile:
+                        reference_file = myfile
+                    if secondary in myfile:
+                        secondary_file = myfile
 
-                gammaProcess(masterFile, slaveFile, "IFM", dem=dem, dem_source=dem_source, rlooks=rlooks,
+                gammaProcess(reference_file, secondary_file, "IFM", dem=dem, dem_source=dem_source, rlooks=rlooks,
                              alooks=alooks, inc_flag=inc_flag, look_flag=look_flag, los_flag=los_flag,
                              time=time)
 

--- a/hyp3_insar_gamma/unwrapping_geocoding.py
+++ b/hyp3_insar_gamma/unwrapping_geocoding.py
@@ -16,15 +16,15 @@ def data2geotiff(inname, outname, dempar, type_):
     execute(f"data2geotiff {dempar} {inname} {type_} {outname}", uselogging=True)
 
 
-def unwrapping_geocoding(master, slave, step="man", rlooks=10, alooks=2, trimode=0,
+def unwrapping_geocoding(reference, secondary, step="man", rlooks=10, alooks=2, trimode=0,
                          npatr=1, npata=1, alpha=0.6):
     dem = "./DEM/demseg"
     dempar = "./DEM/demseg.par"
     lt = "./DEM/MAP2RDC"
-    ifgname = "{}_{}".format(master, slave)
+    ifgname = "{}_{}".format(reference, secondary)
     offit = "{}.off.it".format(ifgname)
-    mmli = master + ".mli"
-    smli = slave + ".mli"
+    mmli = reference + ".mli"
+    smli = secondary + ".mli"
 
     if not os.path.isfile(dempar):
         logging.error("ERROR: Unable to find dem par file {}".format(dempar))
@@ -132,8 +132,8 @@ def main():
         prog='unwrapping_geocoding.py',
         description=__doc__,
     )
-    parser.add_argument("master", help='Master scene identifier')
-    parser.add_argument("slave", help='Slave scene identifier')
+    parser.add_argument("reference", help='Reference scene identifier')
+    parser.add_argument("secondary", help='Secondary scene identifier')
     parser.add_argument("-s", "--step", default='man', help='Level of interferogram for unwrapping (def=man)')
     parser.add_argument("-r", "--rlooks", default=10, help="Number of range looks (def=10)")
     parser.add_argument("-a", "--alooks", default=2, help="Number of azimuth looks (def=2)")
@@ -151,7 +151,7 @@ def main():
     logging.getLogger().addHandler(logging.StreamHandler())
     logging.info("Starting run")
 
-    unwrapping_geocoding(args.master, args.slave, step=args.step, rlooks=args.rlooks, alooks=args.alooks,
+    unwrapping_geocoding(args.reference, args.secondary, step=args.step, rlooks=args.rlooks, alooks=args.alooks,
                          trimode=args.tri, npatr=args.npatr, npata=args.npata, alpha=args.alpha)
 
 


### PR DESCRIPTION
* Changes all master/slave references to reference/secondary
  * Recommended: https://comet.nerc.ac.uk/about-comet/insar-terminology/
  * Following convention in ISCE: https://github.com/isce-framework/isce2/releases/tag/v2.4.0

Also:
* Drops what appears to be unused creation of an `hdf5.txt` file, which doesn't end up in the product directory, and likely was from a historical use of MapReady to generate HDF5 files