### PR TITLE
Release: Hotfix bump hyp3lib to get apply_wb_mask fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.2](https://github.com/ASFHyP3/hyp3-insar-gamma/compare/v2.1.1...v2.1.2)
+
+### Fixed
+* HyP3v1 water mask (beta) option will again mask out water based on 
+  [GSHHG f](http://www.soest.hawaii.edu/wessel/gshhg/) shapes, buffered 3000m 
+  (seaward) from the coastline
+
 ## [2.1.1](https://github.com/ASFHyP3/hyp3-insar-gamma/compare/v2.1.0...v2.1.1)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * HyP3v1 water mask (beta) option will again mask out water based on 
   [GSHHG f](http://www.soest.hawaii.edu/wessel/gshhg/) shapes, buffered 3000m 
   (seaward) from the coastline
+* Upgraded to hyp3-lib v1.6.0 from v1.5.0
 
 ## [2.1.1](https://github.com/ASFHyP3/hyp3-insar-gamma/compare/v2.1.0...v2.1.1)
 

--- a/conda-env.yml
+++ b/conda-env.yml
@@ -14,7 +14,7 @@ dependencies:
   - wheel
   # For running
   - boto3
-  - hyp3lib>=1.5.0,<2
+  - hyp3lib>=1.6.0,<2
   - importlib_metadata
   - lxml
   - pillow

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
 
     install_requires=[
         'boto3',
-        'hyp3lib>=1.5.0,<2',
+        'hyp3lib>=1.6.0,<2',
         'hyp3proclib>=1.0.1,<2',
         'importlib_metadata',
         'lxml',


### PR DESCRIPTION
This will cause both the prod and test (once tag is brought into develop) containers to rebuild and pick up the newest version of hyp3lib with the water mask fix.  